### PR TITLE
Update origin_url redirect to auth state

### DIFF
--- a/src/app/data.service.ts
+++ b/src/app/data.service.ts
@@ -22,18 +22,19 @@ export class DataService {
     return this.user === null ? false : true;
   }
 
-  public getSSO() {
+  public getSSO(path: string) {
     const url = 'https://gymkhana.iitb.ac.in/sso/oauth/authorize/';
     const clientid = '4Id5WpIQqpGYGflJJqGj9hPgGImTyQGxQuNU8Llh';
     const scope = 'basic profile picture program ldap';
     const baseHref = document.getElementsByTagName('base')[0].href || '';
     const redir = `${baseHref}login`;
-    return `${url}?client_id=${clientid}&response_type=code&scope=${scope}&redirect_uri=${redir}`;
+    const state = encodeURI(path);
+    return `${url}?client_id=${clientid}&response_type=code&scope=${scope}&redirect_uri=${redir}&state=${state}`;
   }
 
   public gotoSSO() {
-    localStorage.setItem('login_redir', window.location.pathname)
-    window.location.href = this.getSSO();
+    var path = window.location.href;
+    window.location.href = this.getSSO(path);
   }
 
   public ensureLogin() {

--- a/src/app/login/login.component.ts
+++ b/src/app/login/login.component.ts
@@ -12,6 +12,7 @@ import { IUser } from '../interfaces';
 export class LoginComponent implements OnInit {
 
   code: string;
+  origin_url: string;
 
   constructor(
     private activatedRoute: ActivatedRoute,
@@ -23,6 +24,8 @@ export class LoginComponent implements OnInit {
   ngOnInit() {
     this.activatedRoute.queryParams.subscribe(params => {
       this.code = params.code;
+      const url = new URL(window.location.href);
+      this.origin_url = decodeURI(url.searchParams.get("state"));
       this.golang();
     });
   }
@@ -33,14 +36,7 @@ export class LoginComponent implements OnInit {
       redirect_uri: window.location.href.split('?')[0]
     }).subscribe(r => {
       this.dataService.setUser(r);
-
-      const redir = localStorage.getItem('login_redir')
-      if (redir && redir != "") {
-        this.router.navigateByUrl(redir);
-        localStorage.removeItem('login_redir')
-      } else {
-        this.router.navigate(['/home']);
-      }
+      window.location.href = this.origin_url;
     }, (e) => {
       alert(e.message);
     });


### PR DESCRIPTION
Earlier local storage was used for redirecting to origin URL. But the deployed webapp is not at base URL (/forms), the redirection feature was not working, and always redirected to home. 

Auth state of SSO is used for storing the origin_url, which is then used to redirect after login.